### PR TITLE
Update deasync version in package.json so that it will install on node 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/crobays/descrevit",
   "dependencies": {
-    "deasync": "0.0.10"
+    "deasync": "^0.1.4"
   }
 }


### PR DESCRIPTION
Currently if you attempt an `npm install` on this package (or `require-install` which depends on it) in node 5 it will fail to install because deasync is incompatible. Bumping the version number of deasync fixes this.
